### PR TITLE
[#11] Prevent Wisp pan gesture on gesture-sensitive UIControls

### DIFF
--- a/Sources/Extensions/ScrollableControl.swift
+++ b/Sources/Extensions/ScrollableControl.swift
@@ -1,0 +1,15 @@
+//
+//  ScrollableControl.swift
+//  Wisp
+//
+//  Created by 김민성 on 8/12/25.
+//
+
+import UIKit
+
+protocol ScrollableControl: UIControl { }
+
+extension UIDatePicker: ScrollableControl { }
+extension UISegmentedControl: ScrollableControl { }
+extension UISlider: ScrollableControl { }
+extension UISwitch: ScrollableControl { }

--- a/Sources/Transition/WispPresentationController.swift
+++ b/Sources/Transition/WispPresentationController.swift
@@ -202,11 +202,12 @@ extension WispPresentationController: UIGestureRecognizerDelegate {
             }
         }
         
-        /// blocks `wisp`'s `pan gesture` when tried to pan `UIControls`.
+        /// blocks `wisp`'s `pan gesture` when tried to pan 'scrollable' `UIControls`.
         let subControls: Set<UIControl> = findSubViews(in: view)
-        for control in subControls {
+        let scrollableSubControls = subControls.filter { $0 is ScrollableControl }
+        for control in scrollableSubControls {
             if control.isDescendant(of: view){
-                let controlConvertedFrame = view.convert(control.frame, to: view)
+                let controlConvertedFrame = control.superview?.convert(control.frame, to: cardContainerView) ?? .zero
                 if controlConvertedFrame.contains(gesturePoint) {
                     return false
                 }
@@ -267,7 +268,7 @@ extension WispPresentationController: UIGestureRecognizerDelegate {
             (isAtRightEdge && velocity.gestureDirections == .left) ||
             (isAtBottomEdge && velocity.gestureDirections == .up)
         {
-            scrollView.panGestureRecognizer.require(toFail: self.dragPanGesture)
+            scrollView.panGestureRecognizer.state = .ended
             return true
         } else {
             return false


### PR DESCRIPTION
This change prevents Wisp's pan gesture from being recognized when interacting with certain gesture-sensitive `UIControl`s.  
Such controls are those that inherently rely on pan-like interactions, for example: `UISegmentedControl`, `UISwitch`, etc.  

This ensures that Wisp’s pan gesture behavior does not interfere with the native interaction of these controls, providing a smoother and more intuitive user experience.