### PR TITLE
[#13] Fix safe area issue in presented view controller

### DIFF
--- a/Sources/Transition/WispPresentationAnimator.swift
+++ b/Sources/Transition/WispPresentationAnimator.swift
@@ -47,39 +47,22 @@ extension WispPresentationAnimator: UIViewControllerAnimatedTransitioning {
         }
         let wispView = wispVC.view!
         
-        cardContainerView.translatesAutoresizingMaskIntoConstraints = false
-        wispView.translatesAutoresizingMaskIntoConstraints = false
-        
         containerView.addSubview(cardContainerView)
         cardContainerView.addSubview(wispView)
         
         let configuration = context.configuration
         let presentedAreaInset = context.configuration.layout.presentedAreaInset
         
-        // Setting Initial Position
-        let topConstraint = cardContainerView.topAnchor.constraint(
-            equalTo: containerView.topAnchor,
-            constant: startFrame.minY
-        )
-        let leftConstraint = cardContainerView.leftAnchor.constraint(
-            equalTo: containerView.leftAnchor,
-            constant: startFrame.minX
-        )
-        let rightConstraint = cardContainerView.rightAnchor.constraint(
-            equalTo: containerView.rightAnchor,
-            constant: -(containerView.frame.width - startFrame.maxX)
-        )
-        let bottomConstraint = cardContainerView.bottomAnchor.constraint(
-            equalTo: containerView.bottomAnchor,
-            constant: -(containerView.frame.height - startFrame.maxY)
-        )
-        NSLayoutConstraint.activate([topConstraint, leftConstraint, rightConstraint, bottomConstraint,])
+        cardContainerView.translatesAutoresizingMaskIntoConstraints = true
+        cardContainerView.frame = startFrame
         
         let initialSize = startFrame.size
         let finalSize: CGSize = .init(
             width: containerView.frame.width - (presentedAreaInset.left + presentedAreaInset.right),
             height: containerView.frame.height - (presentedAreaInset.top + presentedAreaInset.bottom)
         )
+        
+        wispView.translatesAutoresizingMaskIntoConstraints = false
         let wispViewWidthConstraint = wispView.widthAnchor.constraint(equalToConstant: finalSize.width)
         let wispViewHeightConstraint = wispView.heightAnchor.constraint(equalToConstant: finalSize.height)
         wispViewWidthConstraint.isActive = true
@@ -105,10 +88,14 @@ extension WispPresentationAnimator: UIViewControllerAnimatedTransitioning {
         
         animator.addAnimations { [weak self] in
             guard let self else { return }
-            topConstraint.constant = presentedAreaInset.top
-            leftConstraint.constant = presentedAreaInset.left
-            rightConstraint.constant = -presentedAreaInset.right
-            bottomConstraint.constant = -presentedAreaInset.bottom
+            guard let window = containerView.window else { return }
+            cardContainerView.frame = .init(
+                x: presentedAreaInset.left,
+                y: presentedAreaInset.top,
+                width: window.bounds.width - (presentedAreaInset.left + presentedAreaInset.right),
+                height: window.bounds.height - (presentedAreaInset.top + presentedAreaInset.bottom)
+            )
+            cardContainerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
             
             self.cardContainerView.layer.cornerRadius = configuration.layout.finalCornerRadius
             self.cardContainerView.layer.maskedCorners = configuration.layout.finalMaskedCorner

--- a/Sources/Transition/WispPresentationAnimator.swift
+++ b/Sources/Transition/WispPresentationAnimator.swift
@@ -53,6 +53,8 @@ extension WispPresentationAnimator: UIViewControllerAnimatedTransitioning {
         let configuration = context.configuration
         let presentedAreaInset = context.configuration.layout.presentedAreaInset
         
+        // ⚠️ Switching back to Auto Layout here may cause safe area layout issues,
+        // especially when presenting view controllers with navigation bars.
         cardContainerView.translatesAutoresizingMaskIntoConstraints = true
         cardContainerView.frame = startFrame
         

--- a/Sources/Transition/WispPresentationController.swift
+++ b/Sources/Transition/WispPresentationController.swift
@@ -132,7 +132,6 @@ private extension WispPresentationController {
             } else {
                 UIView.springAnimate(withDuration: 0.5, options: .allowUserInteraction) {
                     view.transform = .identity
-                    view.translatesAutoresizingMaskIntoConstraints = false
                     view.layoutIfNeeded()
                 }
             }


### PR DESCRIPTION
Changed `cardContainerView` layout in custom transition from AutoLayout to frame-based implementation.  
This prevents safe area misalignment when presenting a navigation controller.  

NOTE: Reverting back to AutoLayout may reintroduce safe area issues.