### PR TITLE
[#19] Fix: capture cell snapshot at dismissal instead of presentation

### DIFF
--- a/Sources/Wisp Managing/WispManager.swift
+++ b/Sources/Wisp Managing/WispManager.swift
@@ -113,10 +113,16 @@ private extension WispManager {
                                          startFrame.height / convertedCellFrame.height)
         restoringCard.layer.cornerRadius = context.configuration.layout.finalCornerRadius / cornerRadiusProportion
         
+        let cellRecentImage = UIGraphicsImageRenderer(bounds: targetCell.contentView.bounds).image { _ in
+            targetCell.contentView.drawHierarchy(in: targetCell.contentView.bounds, afterScreenUpdates: true)
+        }
+        let imageView = UIImageView(image: cellRecentImage)
+        imageView.backgroundColor = targetCell.backgroundColor
+        
         // restoring card snapshot 설정
         restoringCard.setupSnapshots(
             viewSnapshot: context.presentedSnapshot,
-            cellSnapshot: context.sourceCellSnapshot
+            cellSnapshot: imageView
         )
         
         // restoring card 초기 위치 확정


### PR DESCRIPTION
Previously, the library captured a snapshot of the cell at the time of presentation and reused it during dismissal.
However, this approach caused issues when the cell’s content was updated while the view controller was presented, resulting in outdated visuals during the restore animation.

This PR changes the behavior to capture the cell’s snapshot at the moment of dismissal.
By doing so, the restoring card always reflects the latest state of the cell, providing a smoother and more accurate transition.