### PR TITLE
[#18] Remove default blur effect from presented card background

### DIFF
--- a/Sources/Transition/WispPresentationController.swift
+++ b/Sources/Transition/WispPresentationController.swift
@@ -17,12 +17,6 @@ internal class WispPresentationController: UIPresentationController {
         }
     }
     private let feedbackGenerator = UIImpactFeedbackGenerator(style: .light)
-    private let blurAnimator = UIViewPropertyAnimator(
-        duration: 2,
-        controlPoint1: .init(x: 0, y: 0.3),
-        controlPoint2: .init(x: 0.65, y: 0.23)
-    )
-    let tapRecognizingBlurView = UIVisualEffectView(effect: nil)
     private let cardContainerView: UIView
     private let wispDismissableVC: any WispPresented
     
@@ -40,7 +34,6 @@ internal class WispPresentationController: UIPresentationController {
             presentedViewController: self.wispDismissableVC,
             presenting: presentingViewController
         )
-        self.blurAnimator.pausesOnCompletion = true
         self.feedbackGenerator.prepare()
         
         dragPanGesture.delegate = self
@@ -48,40 +41,20 @@ internal class WispPresentationController: UIPresentationController {
     
     override func presentationTransitionWillBegin() {
         guard let containerView else { return }
-        containerView.addSubview(tapRecognizingBlurView)
-        tapRecognizingBlurView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            tapRecognizingBlurView.topAnchor.constraint(equalTo: containerView.topAnchor),
-            tapRecognizingBlurView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-            tapRecognizingBlurView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-            tapRecognizingBlurView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
-        ])
         containerView.layoutIfNeeded()
         
-        tapGesture.addTarget(self, action: #selector(containerBlurDidTapped))
-        tapRecognizingBlurView.addGestureRecognizer(tapGesture)
+        tapGesture.addTarget(self, action: #selector(containerViewDidTapped))
+        containerView.addGestureRecognizer(tapGesture)
         
         dragPanGesture.allowedScrollTypesMask = [.continuous]
         dragPanGesture.addTarget(self, action: #selector(dragPanGesturehandler))
         dragPanGesture.maximumNumberOfTouches = 1
         cardContainerView.addGestureRecognizer(dragPanGesture)
-        
-        blurAnimator.addAnimations { [weak self] in
-            self?.tapRecognizingBlurView.effect = UIBlurEffect(style: .regular)
-        }
-        blurAnimator.startAnimation()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            self?.blurAnimator.stopAnimation(true)
-        }
     }
     
     override func presentationTransitionDidEnd(_ completed: Bool) { }
     
-    override func dismissalTransitionWillBegin() {
-        tapRecognizingBlurView.effect = nil
-        blurAnimator.stopAnimation(true)
-        blurAnimator.pausesOnCompletion = false
-    }
+    override func dismissalTransitionWillBegin() { }
     
     override func dismissalTransitionDidEnd(_ completed: Bool) { }
     
@@ -91,9 +64,7 @@ internal class WispPresentationController: UIPresentationController {
 // MARK: - Gesture Recognizer Handling
 private extension WispPresentationController {
     
-    @objc func containerBlurDidTapped(_ sender: UITapGestureRecognizer) {
-        blurAnimator.stopAnimation(true)
-        tapRecognizingBlurView.effect = nil
+    @objc func containerViewDidTapped(_ sender: UITapGestureRecognizer) {
         wispDismissableVC.dismissCard()
     }
     

--- a/Sources/WispCardViewController/WispCardViewController.swift
+++ b/Sources/WispCardViewController/WispCardViewController.swift
@@ -12,7 +12,6 @@ import UIKit
 class WispCardViewController: UIViewController {
     
     let rootView: WispCardView
-    private let tapGesture = UITapGestureRecognizer()
     private let dragPanGesture = UIPanGestureRecognizer()
     
     init(
@@ -42,7 +41,6 @@ class WispCardViewController: UIViewController {
 extension WispCardViewController {
     
     private func setupGestures() {
-        tapGesture.addTarget(self, action: #selector(backgroundBlurTapped))
         dragPanGesture.addTarget(self, action: #selector(dragPanGesturehandler))
         dragPanGesture.allowedScrollTypesMask = [.continuous]
         

--- a/Sources/WispPresented/WispPresented.swift
+++ b/Sources/WispPresented/WispPresented.swift
@@ -18,12 +18,6 @@ import UIKit
 public extension WispPresented {
     
     func dismissCard(withVelocity initialVelocity: CGPoint = .zero) {
-        // 배경 블러 없애기
-        guard let presentationController = presentationController as? WispPresentationController else {
-            return
-        }
-        presentationController.tapRecognizingBlurView.effect = nil
-        
         if isBeingPresented {
             guard
                 let wispTransitioningDelegate = transitioningDelegate as? WispTransitioningDelegate


### PR DESCRIPTION
Previously, the presented card background applied a default blur effect during custom transitions.
However, the blur effect should not be enforced by the library itself, as it is considered a customizable area for the library users.

Since the main purpose of this library is to provide smooth card expansion and restoration animations, this PR removes the built-in blur effect.
Developers can now freely apply their own background styling, including blur effects, if desired.