### PR TITLE
[#33] Improve dismissing and restoring animation behavior

### DIFF
--- a/Sources/Extensions/UIViewController+Wisp.swift
+++ b/Sources/Extensions/UIViewController+Wisp.swift
@@ -32,7 +32,9 @@ internal extension UIViewController {
             wispTransitioningDelegate.presentingAnimator.stopAnimation(false)
             wispTransitioningDelegate.presentingAnimator.finishAnimation(at: .current)
         }
-        startCardDismissing(withVelocity: initialVelocity)
+        Task {
+            startCardDismissing(withVelocity: initialVelocity)
+        }
     }
     
     private func startCardDismissing(withVelocity initialVelocity: CGPoint) {

--- a/Sources/Transition/WispPresentationController.swift
+++ b/Sources/Transition/WispPresentationController.swift
@@ -18,7 +18,6 @@ internal class WispPresentationController: UIPresentationController {
     }
     private let feedbackGenerator = UIImpactFeedbackGenerator(style: .light)
     private let cardContainerView: UIView
-    internal let wispDismissableVC: UIViewController
     
     private let tapGesture = UITapGestureRecognizer()
     private let tapRecognizingView = UIView()
@@ -30,10 +29,9 @@ internal class WispPresentationController: UIPresentationController {
         presenting presentingViewController: UIViewController?,
         cardContainerView: UIView
     ) {
-        self.wispDismissableVC = presentedViewController
         self.cardContainerView = cardContainerView
         super.init(
-            presentedViewController: self.wispDismissableVC,
+            presentedViewController: presentedViewController,
             presenting: presentingViewController
         )
         self.feedbackGenerator.prepare()
@@ -75,7 +73,7 @@ internal class WispPresentationController: UIPresentationController {
 private extension WispPresentationController {
     
     @objc func containerViewDidTapped(_ sender: UITapGestureRecognizer) {
-        wispDismissableVC.dismissCard()
+        presentedViewController.dismissCard()
     }
     
     @objc func dragPanGesturehandler(_ gesture: UIPanGestureRecognizer) {
@@ -109,7 +107,7 @@ private extension WispPresentationController {
                 (translation.y > 0.0))
             
             if shouldDismiss {
-                wispDismissableVC.dismissCard(withVelocity: velocity)
+                presentedViewController.dismissCard(withVelocity: velocity)
             } else {
                 UIView.springAnimate(withDuration: 0.5, options: .allowUserInteraction) {
                     view.transform = .identity

--- a/Sources/Wisp Managing/WispManager.swift
+++ b/Sources/Wisp Managing/WispManager.swift
@@ -145,9 +145,15 @@ private extension WispManager {
             for: initialVelocity,
             animatingDistance: distanceDiff.inverted()
         )
-        let timingParameters = UISpringTimingParameters(dampingRatio: 0.8, initialVelocity: velocityVector)
-        let cardRestoringMovingAnimator = UIViewPropertyAnimator(duration: 0.6, timingParameters: timingParameters)
-        let cardRestoringSizeAnimator = UIViewPropertyAnimator(duration: 0.7, dampingRatio: 1)
+        
+        let isAnimationFast = context.configuration.animation.speed == .fast
+        let dampingRatio = isAnimationFast ? 1.0 : 0.8
+        let movingDuration = context.configuration.animation.speed.rawValue
+        let sizeDuration = isAnimationFast ? movingDuration : (movingDuration + 0.1)
+        
+        let timingParameters = UISpringTimingParameters(dampingRatio: dampingRatio, initialVelocity: velocityVector)
+        let cardRestoringMovingAnimator = UIViewPropertyAnimator(duration: movingDuration, timingParameters: timingParameters)
+        let cardRestoringSizeAnimator = UIViewPropertyAnimator(duration: sizeDuration, dampingRatio: 1)
         
         cardRestoringMovingAnimator.addAnimations {
             var newCenter = restoringCard.center

--- a/Sources/WispPresenter.swift
+++ b/Sources/WispPresenter.swift
@@ -94,7 +94,7 @@ public extension WispPresenter {
             return
         }
         if animated {
-            wispPresentaitonController.wispDismissableVC.dismissCard()
+            wispPresentaitonController.presentedViewController.dismissCard()
         } else {
             sourceViewController?.dismiss(animated: false)
             newContext.collectionView?.makeSelectedCellVisible(indexPath: newContext.sourceIndexPath)


### PR DESCRIPTION
This PR introduces several improvements to the dismissing and restoring flow:
- Refactor: Use `presentedViewController` directly in `WispPresentationController` instead of keeping an unnecessary duplicate property.
- Restoring animation now respects `WispConfiguration.animation.speed`, adjusting both duration and damping ratio accordingly.
- Bug fix: Addressed a flickering issue that occurred during restoring animations.