### PR TITLE
[#41] Fix context validation and improve wisp.dismiss behavior

### DIFF
--- a/Sources/Wisp Managing/WispContextStackManager.swift
+++ b/Sources/Wisp Managing/WispContextStackManager.swift
@@ -13,7 +13,7 @@ import Foundation
 
     var currentContext: WispContext? {
         get {
-            return stack.last
+            return getValidCurrentContext()
         }
         set {
             if let newValue {
@@ -29,7 +29,26 @@ import Foundation
         stack.append(context)
     }
     
+    @discardableResult
     func pop() -> WispContext? {
         return stack.popLast()
+    }
+    
+    /// Returns the topmost valid `WispContext` from the stack.
+    ///
+    /// If the most recent context is invalid (its `viewControllerToPresent`is no longer available),
+    /// the method removes it and continues checking down the stack until a valid context is found or the stack is empty.
+    ///
+    /// - Returns: The topmost valid `WispContext`, or `nil` if the stack is empty.
+    private func getValidCurrentContext() -> WispContext? {
+        guard let lastItem = stack.last else {
+            return nil
+        }
+        if lastItem.viewControllerToPresent?.presentingViewController != nil {
+            return lastItem
+        } else {
+            self.pop()
+            return getValidCurrentContext()
+        }
     }
 }


### PR DESCRIPTION
This PR resolves issues related to dismissing view controllers with `Wisp`:
- Added validation logic when checking the topmost context in the stack.
- Updated `wisp.dismiss` so that if the target VC was not presented with Wisp (i.e., not referenced in the context), it will not perform any action by default.

### New Features
- Added an `autoFallback` parameter to allow automatic fallback to standard `UIKit` dismissal when the view controller was not presented via `Wisp`.
``` swift
@MainActor
func dismiss(to indexPath: IndexPath? = nil, animated: Bool = true, autoFallback: Bool = false)
```
